### PR TITLE
Missing the time module

### DIFF
--- a/patch/Python/Setup.embedded
+++ b/patch/Python/Setup.embedded
@@ -62,6 +62,7 @@ resource resource.c
 select selectmodule.c
 syslog syslogmodule.c
 termios termios.c
+time timemodule.c
 unicodedata unicodedata.c
 zlib zlibmodule.c -I$(prefix)/include -lz
 


### PR DESCRIPTION
scripts that imported the time or datetime modules generated error due to the time module missing.
